### PR TITLE
Fix integer overflow in microseconds delay, typos

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@
 
 /// Internal function to implement a variable busy-wait loop.
 /// # Arguments
-/// * 'count' - an i32, the number of times to cycle the loop.
-pub fn delay(count: u32) {
+/// * 'count' - a u64, the number of times to cycle the loop.
+pub fn delay(count: u64) {
     // Our asm busy-wait takes a 16 bit word as an argument,
     // so the max number of loops is 2^16
     let outer_count = count / 65536;
@@ -48,8 +48,8 @@ pub fn delay(count: u32) {
 
 ///delay for N milliseconds
 /// # Arguments
-/// * 'ms' - an u32, number of milliseconds to busy-wait
-pub fn delay_ms(ms: u32) {
+/// * 'ms' - a u64, number of milliseconds to busy-wait
+pub fn delay_ms(ms: u64) {
     // microseconds
     let us = ms * 1000;
     delay_us(us);
@@ -57,10 +57,10 @@ pub fn delay_ms(ms: u32) {
 
 ///delay for N microseconds
 /// # Arguments
-/// * 'us' - an u32, number of microseconds to busy-wait
-pub fn delay_us(us: u32) {
-    let us_lp = avr_config::CPU_FREQUENCY_HZ / 1000000 / 4;
-    let loops = (us * us_lp) as u32;
+/// * 'us' - a u64, number of microseconds to busy-wait
+pub fn delay_us(us: u64) {
+    let us_in_loop = (avr_config::CPU_FREQUENCY_HZ / 1000000 / 4) as u64;
+    let loops = us * us_in_loop;
     delay(loops);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub fn delay(count: u32) {
                  :)}
 }
 
-///delay for N miliseconds
+///delay for N milliseconds
 /// # Arguments
 /// * 'ms' - an u32, number of milliseconds to busy-wait
 pub fn delay_ms(ms: u32) {
@@ -57,12 +57,10 @@ pub fn delay_ms(ms: u32) {
 
 ///delay for N microseconds
 /// # Arguments
-/// * 'ms' - an u32, number of microseconds to busy-wait
+/// * 'us' - an u32, number of microseconds to busy-wait
 pub fn delay_us(us: u32) {
-    // picoseconds
-    let ps = us * 1000;
-    let ps_lp = 1000000000 / (avr_config::CPU_FREQUENCY_HZ / 4);
-    let loops = (ps / ps_lp) as u32;
+    let us_lp = avr_config::CPU_FREQUENCY_HZ / 1000000 / 4;
+    let loops = (us * us_lp) as u32;
     delay(loops);
 }
 


### PR DESCRIPTION
delay_ms() and delay_us() functions don't work correctly (check https://www.reddit.com/r/rust/comments/mjkp9v/arduino_pro_mini_avr_delay_delay_ms_doesnt_work/ for a number of complaints), also making [the reference avr-rust implementation](https://github.com/avr-rust/blink) broken as-is. The reasons seem to include the possible integer overflow at the line 63 at the requested delay of > ~4.3 seconds.

This pull request changes the math in delay_us(), alleviating the problem. As the overflow could still happen with required us >= 2**30, or at about just 1073 seconds, which doesn't look good enough, I also changed the relevant parameters to u64. Tested on a physical Arduino Uno with seconds-range values.