### PR TITLE
Track toolchain in VCS

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
This will lead to a less confusing approach for end users, as they'll be
able to clone the repo and have the toolchain preconfigured.
