### PR TITLE
Set reasonable defaults for cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[unstable]
+build-std = [ "core" ]
+
+[build]
+target = "avr-unknown-gnu-atmega328"


### PR DESCRIPTION
[This](This) sets `build-std=core` by default and uses the atmega328p as the
default target. Users will still need to specify alternate targets if
desired, but it makes the build process much easier for a default case.

In a similar vein as https://github.com/avr-rust/delay/pull/25 and
https://github.com/avr-rust/delay/pull/24, this makes it very simple for a very
common case (the default used in the README and the testing docker container);
if all of these are merged, users building for atmega328p should be able to
just `git clone` and `cargo build --release` and be on their way without need
for additional flags such as `+nightly` or `build-std=core` or `--target`...
