### PR TITLE
Use built-in target

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -19,4 +19,4 @@ WORKDIR /code/delay
 
 ENV AVR_CPU_FREQUENCY_HZ=16000000
 
-CMD ["cargo", "build", "-Z", "build-std=core", "--target", "avr-atmega328p.json", "--release"]
+CMD ["cargo", "build", "-Z", "build-std=core", "--target", "avr-unknown-gnu-atmega328", "--release"]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Example:
 
 ```bash
 export AVR_CPU_FREQUENCY_HZ=16000000
-cargo build -Z build-std=core --target avr-atmega328p.json --release
+cargo build -Z build-std=core --target avr-unknown-gnu-atmega328 --release
 ```
 
 ```rust
@@ -83,7 +83,7 @@ pub mod std {
     #[no_mangle]
     pub unsafe extern "C" fn rust_eh_personality(_state: (), _exception_object: *mut (), _context: *mut ()) -> () {
     }
-    
+
     #[lang = "panic_fmt"]
     #[unwind]
     pub extern fn rust_begin_panic(_msg: (), _file: &'static str, _line: u32) -> ! {


### PR DESCRIPTION
The built-in atmega328p target works well and would make a reasonable default with minimal complexity for new users.