### PR TITLE
Add /.cargo to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .vscode/
+/.cargo


### PR DESCRIPTION
For reference, here is the content of my local `.cargo/config.toml`. With this, the Rust language server will autocomplete for the given target instead of using the host's platform.

```toml
[build]
target = "avr-atmega328p.json"
```