### PR TITLE
[cyacc] Add convenience macros to simplify calling delay functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,25 @@ pub fn delay_cycles<const CYCLES: u64>() {
     Delayer::<CYCLES, 1, 1>::delay_impl()
 }
 
+#[macro_export]
+macro_rules! delay_cycles {
+    ($t:expr) => {
+        $crate::delay_cycles::<{ $t }>()
+    };
+}
+
 /// Maximum value is (25_769_803_784 * 1_000_000 / CPU_FREQUENCY_HZ).
 /// Almost 18 minutes at 24Mhz.
 #[inline(always)]
 pub fn delay_us<const US: u64>() {
     Delayer::<US, {avr_config::CPU_FREQUENCY_HZ as u64}, 1_000_000>::delay_impl()
+}
+
+#[macro_export]
+macro_rules! delay_us {
+    ($t:expr) => {
+        $crate::delay_us::<{ $t }>()
+    };
 }
 
 /// Maximum value is (25_769_803_784 * 1_000 / CPU_FREQUENCY_HZ).
@@ -30,11 +44,25 @@ pub fn delay_ms<const MS: u64>() {
     Delayer::<MS, {avr_config::CPU_FREQUENCY_HZ as u64}, 1_000>::delay_impl()
 }
 
+#[macro_export]
+macro_rules! delay_ms {
+    ($t:expr) => {
+        $crate::delay_ms::<{ $t }>()
+    };
+}
+
 /// Maximum value is (25_769_803_784 * 1 / CPU_FREQUENCY_HZ).
 /// Almost 18 minutes at 24Mhz.
 #[inline(always)]
 pub fn delay_sec<const SEC: u64>() {
     Delayer::<SEC, {avr_config::CPU_FREQUENCY_HZ as u64}, 1>::delay_impl()
+}
+
+#[macro_export]
+macro_rules! delay_sec {
+    ($t:expr) => {
+        $crate::delay_sec::<{ $t }>()
+    };
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Calling delay functions with non-trivial inputs requires using the turbofish operator and braces. For example, a 5 minute delay would have to be called as `delay_sec::<{ 5 * 60 }>()`.

This syntax is a bit clunky and not very user-friendly. Turbofish is an obscure syntax; even the person who literally wrote these functions forgot that you need to use the turbofish to call them (#32), so I think expecting users to remember it just to use the basic functionality of this library is an unnecessary burden.

This PR adds macros for every delay function (delay_cycles!, delay_us!, delay_ms!, delay_sec!) such that for example `delay_sec!(5 * 60)` expands to `delay_sec::<{ 5 * 60 }>()`