### PR TITLE
Statically assert that delays are less than 25,769,803,784 cycles

### DIFF
--- a/src/delay_cycles.rs
+++ b/src/delay_cycles.rs
@@ -72,19 +72,6 @@ struct Selection {
     remainder: u64,
 }
 
-// Compute the intended number of cycles to delay, and panic if it is greater than
-// the maximum supported amount of cycles
-const fn compute_total_cycles(cycles: u64, mul: u64, div: u64) -> u64 {
-    const MAX_SUPPORTED_CYCLES: u64 = 25_769_803_784;
-    
-    // Multiply first to avoid precision loss, and expand to u128 to avoid overflow
-    let result: u128 = (cycles as u128) * (mul as u128) / (div as u128);
-    if result > (MAX_SUPPORTED_CYCLES as u128) {
-        panic!("Error: Tried to delay for too many cycles. The maximum supported delay is 25_769_803_784 cycles");
-    }
-    return result as u64;
-}
-
 const fn cycles(counter_mask: u64, cycles_per_run: u64, cycles_per_iter: u64) -> Cycles {
     Cycles {
         counter_mask,
@@ -116,10 +103,15 @@ const fn select(info: Cycles, cycles: u64, above: u64) -> Selection {
 }
 
 impl<const CYCLES: u64, const MUL: u64, const DIV: u64> Delayer<CYCLES, MUL, DIV> {
-    const TOTAL_CYCLES: u64 = compute_total_cycles(CYCLES, MUL, DIV);
-
-    // With `feature(generic_const_exprs) it becomes possible to construct a static assertion.
-    //const _: [(); 0 - ((Self::TOTAL_CYCLES > 25_769_803_784) as usize)] = [];
+    // Compute the intended number of cycles to delay, and panic if it is greater than
+    // the maximum supported amount of cycles
+    const TOTAL_CYCLES: u64 = {
+        const MAX_SUPPORTED_CYCLES: u64 = 25_769_803_784;
+        // Multiply first to avoid precision loss, and expand to u128 to avoid overflow
+        let result: u128 = (CYCLES as u128) * (MUL as u128) / (DIV as u128);
+        assert!(result <= (MAX_SUPPORTED_CYCLES as u128), "Error: Tried to delay for too many cycles. The maximum supported delay is 25_769_803_784 cycles");
+        result as u64
+    };
 
     // counter mask, cycles per run, cycles per iteration. | cost + worst case remainder cost
     const U32_INFO: Cycles = cycles(0xFFFF_FFFF, 9, 6); // 8 + 3


### PR DESCRIPTION
The maximum delay that the Delayer efficiently supports is 25,769,803,784 cycles. Beyond this, previously the implementation would support slightly longer delays (about 0.3% longer) but use many more instructions to do so, and for even longer delays would overflow silently.

This PR adds a static check that the requested delay is less than 25,769,803,784 cycles. If the delay is longer than that, the compilation panics with an error message stating that the delay is too long.