### PR TITLE
Correct rjmp address (fix infinite loop)

### DIFF
--- a/src/delay_cycles.rs
+++ b/src/delay_cycles.rs
@@ -245,7 +245,10 @@ impl<const CYCLES: u64, const MUL: u64, const DIV: u64> Delayer<CYCLES, MUL, DIV
     /// 2 cycles per run.
     #[inline(always)]
     fn delay_2cycles() {
-        unsafe { asm!("rjmp .", options(nomem, nostack, preserves_flags),) }
+        unsafe { asm!(
+            "rjmp 1f",
+            "1:",
+            options(nomem, nostack, preserves_flags),) }
     }
 
     /// 1 instruction.


### PR DESCRIPTION
Until now I had not ran the code. I merely verified that the assembly output was what I expected.

Because `rjmp` on AVR always jump at the given address **plus one instruction** (ie: plus 2 bytes). My reasoning was that `rjmp .` means to jump at the address of `rjmp`, and the hardware will add two, therefore it will jump to the next instruction. 

But of course this is a silly assumption. The assembler (gas) knows about this rule. And it will actually subtract two from any constant passed to `rjmp` during assembly. That is the point of the assembler. Hiding those little details.

It is interesting to note that disassembling the machine code would have showed the problem by representing the jump under a different form.

The updated code is being used on real hardware (atmega168 if that matters). It appears to work as intended, timing and all.

https://sourceware.org/binutils/docs/as/Dot.html.